### PR TITLE
Update ADK doc according to issue #11

### DIFF
--- a/docs/sessions/state.md
+++ b/docs/sessions/state.md
@@ -82,7 +82,7 @@ from google.adk.agents import LlmAgent
 
 story_generator = LlmAgent(
     name="StoryGenerator",
-    model="gemini-2.0-flash",
+    model="gemini-1.5-flash",
     instruction="""Write a short story about a cat, focusing on the theme: {topic}."""
 )
 
@@ -95,7 +95,7 @@ story_generator = LlmAgent(
 
 * Key Existence: Ensure that the key you reference in the instruction string exists in the session.state. If the key is missing, the agent might misbehave or throw an error.
 * Data Types: The value associated with the key should be a string or a type that can be easily converted to a string.
-* Escaping: If you need to use literal curly braces in your instruction (e.g., for JSON formatting), you'll need to escape them.
+* Escaping: To use literal curly braces in your instruction (e.g., `{{not a state variable}}`), you must double them up. If you need more complex logic, consider using an `InstructionProvider`.
 
 #### Bypassing State Injection with `InstructionProvider`
 
@@ -118,7 +118,7 @@ The `InstructionProvider` function receives a `ReadonlyContext` object, which yo
         return "This is an instruction with {{literal_braces}} that will not be replaced."
 
     agent = LlmAgent(
-        model="gemini-2.0-flash",
+        model="gemini-1.5-flash",
         name="template_helper_agent",
         instruction=my_instruction_provider
     )
@@ -139,7 +139,7 @@ If you want to both use an `InstructionProvider` *and* inject state into your in
         return await instructions_utils.inject_session_state(template, context)
 
     agent = LlmAgent(
-        model="gemini-2.0-flash",
+        model="gemini-1.5-flash",
         name="dynamic_template_helper_agent",
         instruction=my_dynamic_instruction_provider
     )
@@ -164,7 +164,7 @@ This direct injection method is specific to LlmAgent instructions. Refer to the 
 
 State should **always** be updated as part of adding an `Event` to the session history using `session_service.append_event()`. This ensures changes are tracked, persistence works correctly, and updates are thread-safe.
 
-**1\. The Easy Way: `output_key` (for Agent Text Responses)**
+**1. The Easy Way: `output_key` (for Agent Text Responses)**
 
 This is the simplest method for saving an agent's final text response directly into the state. When defining your `LlmAgent`, specify the `output_key`:
 
@@ -179,7 +179,7 @@ This is the simplest method for saving an agent's final text response directly i
     # Define agent with output_key
     greeting_agent = LlmAgent(
         name="Greeter",
-        model="gemini-2.0-flash", # Use a valid model
+        model="gemini-1.5-flash", # Use a valid model
         instruction="Generate a short, friendly greeting.",
         output_key="last_greeting" # Save response to state['last_greeting']
     )
@@ -201,14 +201,14 @@ This is the simplest method for saving an agent's final text response directly i
     # Runner handles calling append_event, which uses the output_key
     # to automatically create the state_delta.
     user_message = Content(parts=[Part(text="Hello")])
-    for event in runner.run(user_id=user_id,
-                            session_id=session_id,
-                            new_message=user_message):
+    async for event in runner.run_async(user_id=user_id,
+                                     session_id=session_id,
+                                     new_message=user_message):
         if event.is_final_response():
           print(f"Agent responded.") # Response text is also in event.content
 
     # --- Check Updated State ---
-    updated_session = await session_service.get_session(app_name=APP_NAME, user_id=USER_ID, session_id=session_id)
+    updated_session = await session_service.get_session(app_name=app_name, user_id=user_id, session_id=session_id)
     print(f"State after agent run: {updated_session.state}")
     # Expected output might include: {'last_greeting': 'Hello there! How can I help you today?'}
     ```
@@ -221,7 +221,7 @@ This is the simplest method for saving an agent's final text response directly i
 
 Behind the scenes, the `Runner` uses the `output_key` to create the necessary `EventActions` with a `state_delta` and calls `append_event`.
 
-**2\. The Standard Way: `EventActions.state_delta` (for Complex Updates)**
+**2. The Standard Way: `EventActions.state_delta` (for Complex Updates)**
 
 For more complex scenarios (updating multiple keys, non-string values, specific scopes like `user:` or `app:`, or updates not tied directly to the agent's final text), you manually construct the `state_delta` within `EventActions`.
 


### PR DESCRIPTION
I have identified several discrepancies between the documentation file `docs/sessions/state.md` and the ADK Python codebase. Here are the recommended changes to ensure the documentation is accurate and up-to-date:

### 1. **Use a valid model name in examples**
The examples in the documentation use "gemini-2.0-flash", which is not a valid model name. This should be updated to a valid model name like "gemini-1.5-flash".

**Current state**: 
```python
story_generator = LlmAgent(
    name="StoryGenerator",
    model="gemini-2.0-flash",
    instruction="Write a short story about a cat, focusing on the theme: {topic}."
)
```

**Proposed Change**:
```python
story_generator = LlmAgent(
    name="StoryGenerator",
    model="gemini-1.5-flash",
    instruction="Write a short story about a cat, focusing on the theme: {topic}."
)
```

**Reasoning**:
Using a valid model name in the documentation makes the examples more practical and avoids confusion for users.

**Reference**:
This change applies to all occurrences of "gemini-2.0-flash" in the document.

### 2. **Use `run_async` in the `output_key` example**
The `output_key` example uses `runner.run` in an `async` function. To maintain consistency with the asynchronous nature of the surrounding code, it should use `runner.run_async`.

**Current state**: 
```python
for event in runner.run(user_id=user_id,
                         session_id=session_id,
                         new_message=user_message):
    if event.is_final_response():
      print(f"Agent responded.")
```

**Proposed Change**:
```python
async for event in runner.run_async(user_id=user_id,
                                     session_id=session_id,
                                     new_message=user_message):
    if event.is_final_response():
      print(f"Agent responded.")
```

**Reasoning**:
The `runners.py` file contains both `run` and `run_async`. Using `run_async` is more appropriate in an `async` context to avoid blocking the event loop.

**Reference**:
[1] https://github.com/google/adk-python/blob/db975dfe2a09a6d056d02bc03c1247ac10f6da7d/src/google/adk/runners.py#L112

### 3. **Correct undefined variables in the `output_key` example**
The `output_key` example uses `APP_NAME` and `USER_ID` which are not defined in the snippet. These should be corrected to `app_name` and `user_id` respectively.

**Current state**: 
```python
updated_session = await session_service.get_session(app_name=APP_NAME, user_id=USER_ID, session_id=session_id)
```

**Proposed Change**:
```python
updated_session = await session_service.get_session(app_name=app_name, user_id=user_id, session_id=session_id)
```

**Reasoning**:
This change corrects a `NameError` in the example code, making it runnable.

**Reference**:
This change is for the code block in the `output_key` section of the documentation.

### 4. **Clarify how to escape curly braces in instruction strings**
The documentation about escaping curly braces is a bit misleading. It suggests using `InstructionProvider` to use literal braces, but it should also explain how to escape them directly within a string.

**Current state**: 
The documentation mentions that you need to escape curly braces but doesn't explain how, and instead points to `InstructionProvider`.

**Proposed Change**:
Add a note explaining that to use literal curly braces, you should double them up. For example: `{{not a state variable}}`.

And update the `InstructionProvider` example to be more direct.

```python
# This is an InstructionProvider
def my_instruction_provider(context: ReadonlyContext) -> str:
    # You can optionally use the context to build the instruction
    # For this example, we'll return a static string with literal braces.
    return "This is an instruction with {{literal_braces}} that will not be replaced."
```

**Reasoning**:
The `inject_session_state` function in `instructions_utils.py` is designed to ignore `{{...}}` syntax, treating it as a literal string rather than a state variable. The documentation should reflect this.

**Reference**:
[2] https://github.com/google/adk-python/blob/db975dfe2a09a6d056d02bc03c1247ac10f6da7d/src/google/adk/utils/instructions_utils.py#L108
