### PR TITLE
Update ADK doc according to issue #20

### DIFF
--- a/docs/sessions/state.md
+++ b/docs/sessions/state.md
@@ -346,6 +346,31 @@ For more comprehensive details on context objects, refer to the [Context documen
 * Updates the session's `last_update_time`.
 * Ensures thread-safety for concurrent updates.
 
+### Safely Accessing State with `.get()`
+
+Since `session.state` behaves like a Python dictionary, you can use the `.get()` method to safely retrieve a value. This is particularly useful when you are not sure if a key exists in the state. Using `.get()` avoids a `KeyError` and allows you to provide a default value if the key is not found.
+
+**Example:**
+
+=== "Python"
+
+    ```python
+    # Assume 'user_preference_theme' is not in session.state
+    theme = session.state.get('user_preference_theme')  # Returns None, no error
+    print(f"Theme: {theme}")
+
+    # Provide a default value
+    theme = session.state.get('user_preference_theme', 'light') # Returns 'light'
+    print(f"Theme: {theme}")
+
+    # If the key exists, it returns the value as usual
+    session.state['user_preference_theme'] = 'dark'
+    theme = session.state.get('user_preference_theme', 'light') # Returns 'dark'
+    print(f"Theme: {theme}")
+    ```
+
+This approach is cleaner and safer than checking for the key's existence with `if 'key' in session.state:`.
+
 ### ⚠️ A Warning About Direct State Modification
 
 Avoid directly modifying the `session.state` collection (dictionary/Map) on a `Session` object that was obtained directly from the `SessionService` (e.g., via `session_service.get_session()` or `session_service.create_session()`) *outside* of the managed lifecycle of an agent invocation (i.e., not through a `CallbackContext` or `ToolContext`). For example, code like `retrieved_session = await session_service.get_session(...); retrieved_session.state['key'] = value` is problematic.


### PR DESCRIPTION
I have analyzed the provided documentation file, `docs/sessions/state.md`, and compared it with the current ADK Python codebase. The documentation is largely accurate and up-to-date. However, I have identified one minor area for improvement that will enhance clarity for developers.

### Proposed Change

I recommend updating the documentation to explicitly mention the availability of the `.get()` method on the `session.state` object, which allows for safely retrieving a value with a default if the key does not exist.

Here is the detailed instruction for the change:

1.  **Explicitly mention the `.get()` method for safe state retrieval.**
    Details of the change.

    **Current state**:
    The documentation provides an example of using `.get()` but does not explicitly describe the method itself.

    **Proposed Change**:
    Add a brief explanation of the `.get()` method in the "Accessing Session State" section, highlighting its utility for avoiding errors when a key might not be present in the state.

    **Reasoning**:
    Explicitly documenting the `.get()` method will improve developer experience by making it clear how to safely access state variables that may or may not have been set, thus preventing potential `KeyError` exceptions and simplifying state-handling logic.

    **Reference**:
    The `State` class in the ADK codebase supports the `.get()` method, as seen in the source code.
    - [1] https://github.com/google/adk-python/blob/7556ebc76abd3c776922c2803aed831661cf7f82/src/google/adk/sessions/state.py#L55-L59
