### PR TITLE
Update ADK doc according to issue #45 - 2

### DIFF
--- a/docs/artifacts/index.md
+++ b/docs/artifacts/index.md
@@ -127,6 +127,7 @@ Understanding artifacts involves grasping a few key components: the service that
 
     ```py
     from google.adk.runners import Runner
+    from google.adk.apps import App
     from google.adk.artifacts import InMemoryArtifactService # Or GcsArtifactService
     from google.adk.agents import LlmAgent # Any agent
     from google.adk.sessions import InMemorySessionService
@@ -135,10 +136,14 @@ Understanding artifacts involves grasping a few key components: the service that
     my_agent = LlmAgent(name="artifact_user_agent", model="gemini-2.0-flash")
     artifact_service = InMemoryArtifactService() # Choose an implementation
     session_service = InMemorySessionService()
+    
+    app = App(
+        name="my_artifact_app",
+        root_agent=my_agent
+    )
 
     runner = Runner(
-        agent=my_agent,
-        app_name="my_artifact_app",
+        app=app,
         session_service=session_service,
         artifact_service=artifact_service # Provide the service instance here
     )
@@ -281,6 +286,7 @@ Before you can use any artifact methods via the context objects, you **must** pr
 
     ```python
     from google.adk.runners import Runner
+    from google.adk.apps import App
     from google.adk.artifacts import InMemoryArtifactService # Or GcsArtifactService
     from google.adk.agents import LlmAgent
     from google.adk.sessions import InMemorySessionService
@@ -290,11 +296,16 @@ Before you can use any artifact methods via the context objects, you **must** pr
 
     # Instantiate the desired artifact service
     artifact_service = InMemoryArtifactService()
+    
+    # Create an App
+    app = App(
+        name="my_artifact_app",
+        root_agent=my_agent
+    )
 
     # Provide it to the Runner
     runner = Runner(
-        agent=agent,
-        app_name="artifact_app",
+        app=app,
         session_service=InMemorySessionService(),
         artifact_service=artifact_service # Service must be provided here
     )


### PR DESCRIPTION
This pull request updates the documentation in `docs/artifacts/index.md` to use the `App` class when initializing the `Runner`, as per the instructions in issue #45.