### PR TITLE
Update ADK doc according to issue #45 - 3

### DIFF
--- a/docs/observability/cloud-trace.md
+++ b/docs/observability/cloud-trace.md
@@ -189,6 +189,7 @@ If you want to fully customize your ADK agent runtime, you can enable cloud trac
 # agent_runner.py
 
 from google.adk.runners import Runner
+from google.adk.apps import App
 from google.adk.sessions import InMemorySessionService
 from weather_agent.agent import root_agent as weather_agent
 from google.genai.types import Content, Part
@@ -209,7 +210,8 @@ provider.add_span_processor(processor)
 trace.set_tracer_provider(provider)
 
 session_service = InMemorySessionService()
-runner = Runner(agent=weather_agent, app_name=APP_NAME, session_service=session_service)
+app = App(name=APP_NAME, root_agent=weather_agent)
+runner = Runner(app=app, session_service=session_service)
 
 
 async def main():


### PR DESCRIPTION
This pull request updates the documentation in `docs/observability/cloud-trace.md` to use the `App` class when initializing the `Runner`, as per the instructions in issue #45.